### PR TITLE
fix: even padding in filter sidebar and column header

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,6 +1,11 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+/* REMINDER: the registry package is outside the app root and not picked up
+   by automatic source detection — without this, registry-only classes
+   (e.g. `py-2.5`, `size-2.5!`, `border-none`) are missing from the build */
+@source "../../../../packages/registry/src";
+
 @plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));

--- a/packages/registry/src/components/data-table/data-table-column-header.tsx
+++ b/packages/registry/src/components/data-table/data-table-column-header.tsx
@@ -36,7 +36,7 @@ export function DataTableColumnHeader<TData, TValue>({
       <span className="flex flex-col">
         <ChevronUp
           className={cn(
-            "-mb-0.5! size-3!",
+            "-mb-0.5 size-3",
             column.getIsSorted() === "asc"
               ? "text-accent-foreground"
               : "text-muted-foreground",
@@ -44,7 +44,7 @@ export function DataTableColumnHeader<TData, TValue>({
         />
         <ChevronDown
           className={cn(
-            "-mt-0.5! size-3!",
+            "-mt-0.5 size-3",
             column.getIsSorted() === "desc"
               ? "text-accent-foreground"
               : "text-muted-foreground",

--- a/packages/registry/src/components/data-table/data-table-filter-controls.tsx
+++ b/packages/registry/src/components/data-table/data-table-filter-controls.tsx
@@ -53,7 +53,8 @@ export function DataTableFilterControls() {
         const FilterComponent = FILTER_COMPONENTS[field.type];
         if (!FilterComponent) return null;
         return (
-          <AccordionItem key={value} value={value} className="border-none">
+          // REMINDER: -mx-2 lets the border-b span the full sidebar width despite the parent p-2; px-2 keeps the content aligned
+          <AccordionItem key={value} value={value} className="-mx-2 px-2">
             <AccordionTrigger className="data-[state=closed]:text-muted-foreground data-[state=open]:text-foreground focus-within:data-[state=closed]:text-foreground hover:data-[state=closed]:text-foreground w-full items-center gap-2 px-2 py-0 hover:no-underline">
               <div className="flex w-full items-center justify-between gap-2 truncate py-2 pr-2">
                 <div className="flex items-center gap-2 truncate">

--- a/packages/registry/src/components/data-table/data-table-filter-controls.tsx
+++ b/packages/registry/src/components/data-table/data-table-filter-controls.tsx
@@ -54,8 +54,8 @@ export function DataTableFilterControls() {
         if (!FilterComponent) return null;
         return (
           <AccordionItem key={value} value={value} className="border-none">
-            <AccordionTrigger className="data-[state=closed]:text-muted-foreground data-[state=open]:text-foreground focus-within:data-[state=closed]:text-foreground hover:data-[state=closed]:text-foreground w-full items-center px-2 py-0 hover:no-underline">
-              <div className="flex w-full items-center justify-between gap-2 truncate py-2">
+            <AccordionTrigger className="data-[state=closed]:text-muted-foreground data-[state=open]:text-foreground focus-within:data-[state=closed]:text-foreground hover:data-[state=closed]:text-foreground w-full items-center gap-2 px-2 py-0 hover:no-underline">
+              <div className="flex w-full items-center justify-between gap-2 truncate py-2 pr-2">
                 <div className="flex items-center gap-2 truncate">
                   <p className="text-sm font-medium">{field.label}</p>
                   {value !== field.label.toLowerCase() &&


### PR DESCRIPTION
- override shadcn ui accordion's gap-4 to gap-2 on filter triggers and
  restore pr-2 on the inner row so the reset button no longer floats
  too far from the chevron
- drop the unnecessary `!` important markers on the sort chevrons in
  data-table-column-header; the shadcn Button base already respects
  any explicit size-* class via [&_svg:not([class*='size-'])]:size-4