### PR TITLE
docs: fix broken internal links in full example

### DIFF
--- a/apps/web/src/content/docs/10-full-example.mdx
+++ b/apps/web/src/content/docs/10-full-example.mdx
@@ -64,7 +64,7 @@ export type FilterState = typeof filterSchema._type;
 
 ## 3. Set Up the API Route
 
-Create an API handler with `createDrizzleHandler` that implements three-pass filtering, faceted search, and cursor pagination. See [Database](/docs/database) and [Data Fetching](/docs/data-fetching) for the underlying concepts.
+Create an API handler with `createDrizzleHandler` that implements three-pass filtering, faceted search, and cursor pagination. See [Drizzle ORM](/docs/drizzle-orm) and [Data Fetching](/docs/data-fetching) for the underlying concepts.
 
 ```tsx
 // app/api/route.ts
@@ -100,7 +100,7 @@ export async function GET(req: NextRequest) {
 
 ## 4. Render
 
-Wire up `useInfiniteQuery` with `DataTableInfinite` and populate filter fields dynamically from server-side facet data. See [Components](/docs/components) for all available props.
+Wire up `useInfiniteQuery` with `DataTableInfinite` and populate filter fields dynamically from server-side facet data. See [Components](/docs/ui-components) for all available props.
 
 ```tsx
 // client.tsx


### PR DESCRIPTION
## Summary

Two internal links on the **Full Example** docs page pointed to routes that don't exist:

- `/docs/components` → `/docs/ui-components`
- `/docs/database` → `/docs/drizzle-orm` (also updated the link text from "Database" to "Drizzle ORM" to match the page title)

Both now resolve to real doc pages, consistent with how the other docs reference them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)