### PR TITLE
chore(light/api): rewrite stats/facets filter TODO into a NOTE

### DIFF
--- a/apps/web/src/app/light/api/route.ts
+++ b/apps/web/src/app/light/api/route.ts
@@ -91,7 +91,7 @@ export async function GET(req: NextRequest) {
   // TODO: too many requests, especially when scrolling as stats/facets are not cached and are only needed for initial load
   const [dataRes, chartRes, facetsRes] = await Promise.all([
     fetch(`${tbEndpoint}/api/get?${searchParams.toString()}`),
-    // TODO: we are missing filter in both, the stats and the facets - nothing urgent
+    // NOTE: stats and facets don't respect the applied filters yet - known limitation, fine for now
     fetch(`${tbEndpoint}/api/stats?${statsParams.toString()}`),
     fetch(`${tbEndpoint}/api/facets?${facetsParams.toString()}`),
   ]);


### PR DESCRIPTION
## Summary
Replaces a misleading TODO comment in the light API route handler with a clearer NOTE (`apps/web/src/app/light/api/route.ts:94`).

## Changes
- The old comment (`we are missing filter in both, stats and facets - nothing urgent`) read like a task to be done.
- The new wording (`stats and facets don't respect the applied filters yet - known limitation, fine for now`) makes it explicit this is a known, accepted limitation, not pending work.
- No functional changes — comment-only diff.

## Why
Avoids future contributors treating an intentional tradeoff as unaddressed technical debt, while keeping awareness of the behavior visible in code.